### PR TITLE
Make subprocess invocation safer

### DIFF
--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -182,10 +182,7 @@ class Node:
         ]
         print(starter)
         start = time.time()
-        op = subprocess.Popen(
-            " ".join(starter), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        op.wait()
+        op = subprocess.run(starter, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         duration = time.time() - start
         cmd_output = op.stdout.readlines()
         print(op.stderr.read())


### PR DESCRIPTION
This is **NOT SAFE**:

```python
subprocess.Popen('echo foo && rm -ri /').wait()
```

This is safe:

```python
subprocess.run(('echo', 'foo && rm -ri /'))
```

(The `-i` flag is used instead of `-f` to make life better for any
thrill-seeking soul who decides to run the code samples above.)