### PR TITLE
Change flake8 options, and move to config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+# https://flake8.pycqa.org/en/latest/user/options.html
+[flake8]
+count = True
+# used by GitHub editor
+max-line-length = 127
+statistics = True

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,10 +27,7 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8
     - name: Test with pytest
       run: |
         pip install pytest


### PR DESCRIPTION
flake8 is configured to always exit with an exit code of 0. This seems
pointless: developers are likely to check CI output only when an error
occurs, so why bother running flake8 and then making it report success
regardless of what it finds?

Drop the McCabe cyclomatic complexity check. It's a useful metric of
complexity, but affinity is currently very fresh and rough, and I'd like
us to concentrate more on high-level design issues like "how will
affinity be used by tests" and "might it be useful for a Mesh to be
usable as a set or a dict?"

Move the flake8 configuration options to a config file. This makes it
more convenient for developers to run flake8 with the same options that
are used by CI.