### PR TITLE
Move cli commands to its own module

### DIFF
--- a/receptor_affinity/cli.py
+++ b/receptor_affinity/cli.py
@@ -1,6 +1,40 @@
 import click
+from receptor import ReceptorConfig
+
+from .debugger import run_as_debugger
+from .ping import run_as_ping
 
 
-@click.group()
+@click.group(
+    help="Helper commands to check receptor's binding affinity."
+)
 def cli():
     pass
+
+
+@cli.group(help="Commands to run receptor with different behaviors.")
+def receptor():
+    pass
+
+
+@receptor.command("debugnode")
+@click.option("--data-path", default=None)
+@click.option("--node-id", default="diag_node")
+@click.option("--listen", default=None)
+@click.option("--api-address", default=None)
+@click.option("--api-port", default=None)
+def debugnode(data_path, node_id, listen, api_address, api_port):
+    run_as_debugger(data_path, node_id, listen, api_address, api_port)
+
+
+@receptor.command("ping")
+@click.option("--data-path", default="/tmp/receptor")
+@click.option("--peer", default="receptor://127.0.0.1:8889")
+@click.option("--id", default="node1")
+@click.option("--node-id", default="ping-node")
+@click.option("--count", default=10)
+def ping(data_path, peer, id, node_id, count):
+    config = ReceptorConfig(
+        ["-d", data_path, "--node-id", node_id, "ping", "--peer", peer, id, "--count", str(count)]
+    )
+    run_as_ping(config)

--- a/receptor_affinity/debugger.py
+++ b/receptor_affinity/debugger.py
@@ -5,7 +5,6 @@ import time
 import uuid
 import dateutil.parser
 
-import click
 from aiohttp import web
 
 from receptor import Controller
@@ -117,13 +116,7 @@ class DiagNode:
         return web.Response(text=json.dumps(responses))
 
 
-@click.command("debugnode")
-@click.option("--data-path", default=None)
-@click.option("--node-id", default="diag_node")
-@click.option("--listen", default=None)
-@click.option("--api-address", default=None)
-@click.option("--api-port", default=None)
-def start(data_path, node_id, listen, api_address, api_port):
+def run_as_debugger(data_path, node_id, listen, api_address, api_port):
     controller = DiagNode(data_path, node_id, listen)
     controller.start("")
     app = web.Application()
@@ -133,7 +126,3 @@ def start(data_path, node_id, listen, api_address, api_port):
     app.add_routes([web.get("/connections", controller.connections)])
 
     web.run_app(app, host=api_address, port=api_port)
-
-
-if __name__ == "__main__":
-    start()

--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -15,8 +15,6 @@ import requests
 import yaml
 from prometheus_client.parser import text_string_to_metric_families
 
-from . import debugger
-from . import ping
 from .utils import Conn
 from .utils import net_check
 from .utils import random_port
@@ -167,8 +165,9 @@ class Node:
 
         starter = [
             "time",
-            "python",
-            ping.__file__,
+            "affinity",
+            "receptor",
+            "debugnode",
             "--data-path",
             self.data_path,
             "--node-id",
@@ -201,8 +200,9 @@ class DiagNode(Node):
 
     def _construct_run_command(self):
         starter = [
-            "python",
-            debugger.__file__,
+            "affinity",
+            "receptor",
+            "debugnode",
             "--listen",
             self.listen,
             "--data-path",

--- a/receptor_affinity/ping.py
+++ b/receptor_affinity/ping.py
@@ -1,10 +1,8 @@
 import asyncio
 import time
 
-import click
 
 from receptor import Controller
-from receptor import ReceptorConfig
 
 
 def run_as_ping(config):
@@ -41,20 +39,3 @@ def run_as_ping(config):
     controller = Controller(config)
     # controller.loop = asyncio.get_event_loop()
     return controller.run(ping_entrypoint)
-
-
-@click.command("ping")
-@click.option("--data-path", default="/tmp/receptor")
-@click.option("--peer", default="receptor://127.0.0.1:8889")
-@click.option("--id", default="node1")
-@click.option("--node-id", default="ping-node")
-@click.option("--count", default=10)
-def ping(data_path, peer, id, node_id, count):
-    config = ReceptorConfig(
-        ["-d", data_path, "--node-id", node_id, "ping", "--peer", peer, id, "--count", str(count)]
-    )
-    run_as_ping(config)
-
-
-if __name__ == "__main__":
-    ping()


### PR DESCRIPTION
Affinity has a dedicate cli module for its commands. That said move
commands that were on different modules to the cli module.