### PR TITLE
Run yamllint in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,34 +1,45 @@
+---
 name: Python package
 
-on:
-- pull_request
-- push
+'on':
+  - pull_request
+  - push
 
 jobs:
-  build:
 
+  build:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .
-        python -c 'import receptor_affinity; print(receptor_affinity.__version__)'
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        flake8
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          python -c 'import receptor_affinity; print(receptor_affinity.__version__)'
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          flake8
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest
+
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v1
+      - name: Lint yaml files
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_strict: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+# https://yamllint.readthedocs.io/en/stable/rules.html
+extends: default
+rules:
+  line-length:
+    # used by GitHub editor
+    max: 127


### PR DESCRIPTION
Doing this helps to eliminate a source of bike-shedding.

For all yamllint configuration options than can be pulled into a
separate configuration file, do so, so that developers can locally lint
files before pushing to GitHub.

Currently, only the GitHub CI configuration file(s) are subject to this
linting.