### PR TITLE
Rename mesh generation methods

### DIFF
--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -289,7 +289,7 @@ class Mesh:
             del self.nodes[node_name]
 
     @staticmethod
-    def generate_mesh(controller_port, node_count, conn_method, profile=False):
+    def gen(controller_port, node_count, conn_method, profile=False):
         mesh = Mesh()
         mesh.add_node(
             Node(
@@ -318,7 +318,7 @@ class Mesh:
         return mesh
 
     @staticmethod
-    def generate_random_mesh(controller_port, node_count, max_conn_count, profile):
+    def gen_random(controller_port, node_count, max_conn_count, profile):
         def peer_function(mesh, cur_node):
             nconns = defaultdict(int)
             print(mesh)
@@ -337,19 +337,15 @@ class Mesh:
             else:
                 return random.choices(available_nodes, k=int(random.random() * max_conn_count))
 
-        mesh = Mesh.generate_random_mesh(
-            controller_port, node_count, peer_function, profile
-        )
+        mesh = Mesh.gen_random(controller_port, node_count, peer_function, profile)
         return mesh
 
     @staticmethod
-    def generate_flat_mesh(controller_port, node_count, profile):
+    def gen_flat(controller_port, node_count, profile):
         def peer_function(*args):
             return ["controller"]
 
-        mesh = Mesh.generate_random_mesh(
-            controller_port, node_count, peer_function, profile
-        )
+        mesh = Mesh.gen_random(controller_port, node_count, peer_function, profile)
         return mesh
 
     def dump_yaml(self, filename=".last-mesh.yaml"):


### PR DESCRIPTION
The `Mesh` class has several methods for generating instances. Rename
them:

*   Remove the `_mesh` suffix. The methods are defined on the `Mesh`
    class. Why do the methods names need to be redundant about that?
*   Shorten `generate` to `gen`. The latter is more concise, while still
    being an obvious shortcut, much like how "del" is often used instead
    of "delete."

This produces the following changes:

*   `generate_mesh` → `gen`
*   `generate_random_mesh` → `gen_random`
*   `generate_flat_mesh` → `gen_flat`

Note that the following methods also exist on class `Mesh`:

*   `generate_routes`
*   `generate_dot`

These methods don't actually generate anything in a procedural manner.
Instead, they take existing information and compile it for debugging
purposes. IMO, the names are misnomers, and they could be renamed to
something like:

*   `get_routes` (This would provide symmetry with `node.get_routes`.)
*   `as_dot`