### PR TITLE
Rename mesh loading method

### DIFF
--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -407,7 +407,7 @@ class Mesh:
         print("all killed")
 
     @staticmethod
-    def load_mesh_from_file(filename, use_diag_node=False):
+    def load_from_file(filename, use_diag_node=False):
         with open(filename) as f:
             data = yaml.safe_load(f)
 


### PR DESCRIPTION
Rename `Mesh.load_mesh_from_file` to `Mesh.load_from_file`. The method
is already defined on the `Mesh` class, so placing "mesh" in the method
name is redundant.

This PR requires a corresponding change in receptor.