### PR TITLE
Make pre-commit hooks available

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
           pip install poetry
           poetry install
       - name: Run flake8
-        run: poetry run flake8
+        run: scripts/lint-flake8.sh
 
   lint-yamllint:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
           pip install poetry
           poetry install
       - name: Run yamllint
-        run: poetry run yamllint --strict .
+        run: scripts/lint-yamllint.sh
 
   test:
     runs-on: ubuntu-latest
@@ -59,9 +59,9 @@ jobs:
           pip install poetry
           poetry install
       - name: Run pytest
-        run: poetry run pytest
+        run: scripts/test.sh
 
-  lint-black:
+  format:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -75,7 +75,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
-      - name: Run black, and check for changes
-        run: |
-          poetry run black .
-          git diff --exit-code
+      - name: Run black
+        run: scripts/format.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+# Don't actually make changes on behalf of the dev. Just check to see if they
+# forgot to do so.
+poetry run black --check .

--- a/scripts/install-pre-commit.sh
+++ b/scripts/install-pre-commit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+ln -s ../../scripts/pre-commit .git/hooks/pre-commit

--- a/scripts/lint-flake8.sh
+++ b/scripts/lint-flake8.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+poetry run yamllint --strict .

--- a/scripts/lint-yamllint.sh
+++ b/scripts/lint-yamllint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+poetry run flake8

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+# Ensure stashed changes are popped even when checks fail.
+cleanup() {
+    # This command sill fail if `git stash push` didn't push any changes onto
+    # the stack.
+    git stash pop --quiet || true
+}
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+
+git stash push --quiet --keep-index
+for script in scripts/*.sh; do
+    if [ "${script}" == 'scripts/install-pre-commit.sh' ]; then
+        continue
+    fi
+    echo "${script}"
+    "${script}"
+    echo
+done
+
+# vim:set ft=sh:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# coding=utf-8
+set -euo pipefail
+
+poetry run pytest


### PR DESCRIPTION
Keep checks DRY by pushing them into scripts, and calling them from both
github actions and the git pre-commit hook.