### PR TITLE
Rename RouteUnavailableError

### DIFF
--- a/receptor_affinity/exceptions.py
+++ b/receptor_affinity/exceptions.py
@@ -6,16 +6,6 @@ class BaseError(Exception):
     """Base class for all exceptions defined by this library."""
 
 
-class RouteUnavailableError(BaseError):
-    """Routes were requested from an inactive node."""
-
-    def __init__(self, node):
-        self._node_name = node.name
-
-    def __str__(self):
-        return f"Routes were requested from an inactive node, {self._node_name}"
-
-
 class RouteMismatchError(BaseError):
     """A mesh and its nodes have differing routing tables."""
 
@@ -42,3 +32,12 @@ class RouteMismatchError(BaseError):
                 f"Mismatched nodes: {', '.join(node.name for node in self._nodes)}"
             )
             return msg.getvalue()
+
+
+class NodeUnavailableError(BaseError):
+    """An operation was performed on an unavailable node.
+
+    An "unavailable node" is a ``Node`` object that doesn't have a corresponding receptor node
+    process. This exception doesn't specify why the receptor process is unavailable. For example, it
+    might have been cleanly stopped or it might have crashed.
+    """

--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -15,7 +15,7 @@ import requests
 import yaml
 from prometheus_client.parser import text_string_to_metric_families
 
-from .exceptions import RouteMismatchError, RouteUnavailableError
+from .exceptions import RouteMismatchError, NodeUnavailableError
 from .utils import Conn
 from .utils import net_check
 from .utils import random_port
@@ -156,7 +156,7 @@ class Node:
 
     def validate_routes(self) -> None:
         if not self.active:
-            raise RouteUnavailableError(self)
+            raise NodeUnavailableError("Routes were requested from a stopped node.")
         if self.mesh.generate_routes() != self.get_routes():
             raise RouteMismatchError(self.mesh, (self,))
 

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,5 +1,5 @@
 import receptor_affinity
-from receptor_affinity.exceptions import RouteUnavailableError, RouteMismatchError
+from receptor_affinity.exceptions import RouteMismatchError, NodeUnavailableError
 from receptor_affinity.mesh import Mesh, Node
 
 
@@ -7,10 +7,10 @@ def test_version():
     assert hasattr(receptor_affinity, "__version__")
 
 
-def test_str_route_unavailable_error():
-    """Call ``str`` on a ``RouteUnavailableError``."""
+def test_str_stopped_node_error():
+    """Call ``str`` on a ``NodeUnavailableError``."""
     node = Node("my node")
-    err = RouteUnavailableError(node)
+    err = NodeUnavailableError(node)
     str(err)
 
 


### PR DESCRIPTION
Rename it to `NodeUnavailableError`.

If a `Node` object doesn't have a corresponding running receptor
process, then many methods and properties are inaccessible. Rename
exception to better cater to this reality, and make future development a
bit nicer.