### PR TITLE
Drop unused regex

### DIFF
--- a/receptor_affinity/utils.py
+++ b/receptor_affinity/utils.py
@@ -9,17 +9,12 @@ from pyparsing import nums
 from pyparsing import Optional
 from _collections import defaultdict
 import logging
-import re
 
 
 logger = logging.getLogger(__name__)
 
 _ports = defaultdict(dict)
 _dns_cache = {}
-ip_address = re.compile(
-    r"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}"
-    r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-)
 
 
 class Conn:


### PR DESCRIPTION
As a general rule, unused code should be dropped. If we want this regex
back, it'll be right here in the commit history, and IPv4 regexes are
easy enough to write anyway.

Depending upon the use case, other tools might be more suitable. For
example, if pulling the IP address out of a URL, it would be more robust
to use the `urllib.parse.urlparse` and `ipaddress` modules from the
stdlib.