### PR TITLE
Implement Node.pid and Node.pgid

### DIFF
--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,3 +1,7 @@
+import uuid
+
+import pytest
+
 import receptor_affinity
 from receptor_affinity.exceptions import RouteMismatchError, NodeUnavailableError
 from receptor_affinity.mesh import Mesh, Node
@@ -25,3 +29,75 @@ def test_str_route_mismatch_error():
     mesh.add_node(node)
     err = RouteMismatchError(mesh, (node,))
     str(err)
+
+
+def test_node_pid_v1():
+    """Call ``Node.pid`` on a not-yet-started node.
+
+    Assert ``NodeUnavailableError`` is raised.
+    """
+    node = Node(str(uuid.uuid4()))
+    with pytest.raises(NodeUnavailableError):
+        node.pid
+
+
+def test_node_pid_v2():
+    """Call ``Node.pid`` on a started node.
+
+    Assert an int is returned.
+    """
+    node = Node(str(uuid.uuid4()))
+    node.start()
+    try:
+        node_pid = node.pid
+        assert isinstance(node_pid, int)
+    finally:
+        node.stop()
+
+
+def test_node_pid_v3():
+    """Call ``Node.pid`` on a node that has been started and stopped.
+
+    Assert ``NodeUnavailableError`` is raised.
+    """
+    node = Node(str(uuid.uuid4()))
+    node.start()
+    node.stop()
+    with pytest.raises(NodeUnavailableError):
+        node.pid
+
+
+def test_node_pgid_v1():
+    """Call ``Node.pgid`` on a not-yet-started node.
+
+    Assert ``NodeUnavailableError`` is raised.
+    """
+    node = Node(str(uuid.uuid4()))
+    with pytest.raises(NodeUnavailableError):
+        node.pgid
+
+
+def test_node_pgid_v2():
+    """Call ``Node.pgid`` on a started node.
+
+    Assert an int is returned.
+    """
+    node = Node(str(uuid.uuid4()))
+    node.start()
+    try:
+        node_pgid = node.pgid
+        assert isinstance(node_pgid, int)
+    finally:
+        node.stop()
+
+
+def test_node_pgid_v3():
+    """Call ``Node.pgid`` on a node that has been started and stopped.
+
+    Assert ``NodeUnavailableError`` is raised.
+    """
+    node = Node(str(uuid.uuid4()))
+    node.start()
+    node.stop()
+    with pytest.raises(NodeUnavailableError):
+        node.pgid


### PR DESCRIPTION
The methods return the PID and PGID of a node, respectively. Both
methods can fail, and only work correctly when called on a running node.

Of special note is that `Node.stop` now deletes an entry from the
(thread-unsafe!) module-wide `procs` dict. This makes it harder for
clients to get known-stale PIDs and PGIDs.