### PR TITLE
Make Node.wait_for_ports more robust

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,9 @@ ignore_missing_imports = True
 [mypy-prometheus_client.*]
 ignore_missing_imports = True
 
+[mypy-psutil]
+ignore_missing_imports = True
+
 [mypy-pyparsing]
 ignore_missing_imports = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -311,6 +311,17 @@ version = "0.7.1"
 twisted = ["twisted"]
 
 [[package]]
+category = "main"
+description = "Cross-platform lib for process and system monitoring in Python."
+name = "psutil"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "5.6.7"
+
+[package.extras]
+enum = ["enum34"]
+
+[[package]]
 category = "dev"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
@@ -569,7 +580,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "db26a38387399df9d23a1edb989867f66d0f56a7fefb3af63d76ba9be402616e"
+content-hash = "00c1ddf0546c189f52ffbebe4f05457ba13f11c216923c6650c3d945c0f91bb6"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -718,6 +729,19 @@ pluggy = [
 ]
 prometheus-client = [
     {file = "prometheus_client-0.7.1.tar.gz", hash = "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"},
+]
+psutil = [
+    {file = "psutil-5.6.7-cp27-none-win32.whl", hash = "sha256:1b1575240ca9a90b437e5a40db662acd87bbf181f6aa02f0204978737b913c6b"},
+    {file = "psutil-5.6.7-cp27-none-win_amd64.whl", hash = "sha256:28f771129bfee9fc6b63d83a15d857663bbdcae3828e1cb926e91320a9b5b5cd"},
+    {file = "psutil-5.6.7-cp35-cp35m-win32.whl", hash = "sha256:21231ef1c1a89728e29b98a885b8e0a8e00d09018f6da5cdc1f43f988471a995"},
+    {file = "psutil-5.6.7-cp35-cp35m-win_amd64.whl", hash = "sha256:b74b43fecce384a57094a83d2778cdfc2e2d9a6afaadd1ebecb2e75e0d34e10d"},
+    {file = "psutil-5.6.7-cp36-cp36m-win32.whl", hash = "sha256:e85f727ffb21539849e6012f47b12f6dd4c44965e56591d8dec6e8bc9ab96f4a"},
+    {file = "psutil-5.6.7-cp36-cp36m-win_amd64.whl", hash = "sha256:b560f5cd86cf8df7bcd258a851ca1ad98f0d5b8b98748e877a0aec4e9032b465"},
+    {file = "psutil-5.6.7-cp37-cp37m-win32.whl", hash = "sha256:094f899ac3ef72422b7e00411b4ed174e3c5a2e04c267db6643937ddba67a05b"},
+    {file = "psutil-5.6.7-cp37-cp37m-win_amd64.whl", hash = "sha256:fd2e09bb593ad9bdd7429e779699d2d47c1268cbde4dda95fcd1bd17544a0217"},
+    {file = "psutil-5.6.7-cp38-cp38-win32.whl", hash = "sha256:70387772f84fa5c3bb6a106915a2445e20ac8f9821c5914d7cbde148f4d7ff73"},
+    {file = "psutil-5.6.7-cp38-cp38-win_amd64.whl", hash = "sha256:10b7f75cc8bd676cfc6fa40cd7d5c25b3f45a0e06d43becd7c2d2871cbb5e806"},
+    {file = "psutil-5.6.7.tar.gz", hash = "sha256:ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa"},
 ]
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ wait-for = "^1.1.1"
 python-dateutil = "^2.8.1"
 prometheus-client = "^0.7.1"
 typing = "^3.7.4"
+psutil = "^5.6.7"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"

--- a/receptor_affinity/utils.py
+++ b/receptor_affinity/utils.py
@@ -1,6 +1,5 @@
 import logging
 import socket
-from collections import defaultdict
 
 from pyparsing import Group
 from pyparsing import OneOrMore
@@ -9,12 +8,9 @@ from pyparsing import Suppress
 from pyparsing import Word
 from pyparsing import alphanums
 from pyparsing import nums
-from typing import Dict
 
 
 logger = logging.getLogger(__name__)
-
-_ports: Dict[str, Dict[int, bool]] = defaultdict(dict)
 
 
 class Conn:
@@ -81,25 +77,3 @@ def random_port(tcp=True):
     addr, port = s.getsockname()
     s.close()
     return port
-
-
-def net_check(port, addr="localhost", force=False):
-    """Checks the availablility of a port"""
-    port = int(port)
-    if port not in _ports[addr] or force:
-        # First try DNS resolution
-        try:
-
-            addr = socket.gethostbyname(addr)
-
-            # Then try to connect to the port
-            try:
-                socket.create_connection((addr, port), timeout=10)
-                _ports[addr][port] = True
-            except socket.error:
-                logger.exception("failed connection")
-                _ports[addr][port] = False
-        except Exception as e:
-            logger.info(e)
-            _ports[addr][port] = False
-    return _ports[addr][port]


### PR DESCRIPTION
The purpose of `Node.wait_for_ports()` is to wait for the backing
receptor process to bind to the ports it's been told to bind to. It
does the following:

1.  Collect the listen address-port pair. (And, for `DiagNode`, the API
    address-port pair.)
2.  Check to see whether the test runner can connect to each of the
    address-port pairs.

There's one significant problem with this approach: it doesn't check to
see _which_ process has bound to that approach. This is a problem if,
say, one is writing a test case that intentionally asks two receptor
nodes to bind to the same port.

Also of note is that the check touches on system components beyond what
might be strictly necessary for the test to function. For example, a
receptor process might successfully bind to a port, but the test runner
might be unable to connect to it does to firewall policies, or some
interesting networking setup (e.g. one involving a macvtap device in
VEPA or private mode).

This commit rewrites `Node.wait_for_ports()` so that it does the
following:

1.  Collect the listen port and stats port. (And for `DiagNode`, the API
    port.)
2.  Collect all ports that the backing process is listening on.
3.  Check to see whether the former is a subset of the latter.

This allows certain classes of test cases to be written.

This both improves and reduces coverage: the method is now also checking
to see whether the stats port is bound-to, but it's not verifying that
the ports are associated with the correct addresses. In other words, the
method is no longer checking socket addresses. With some additional
work, this can be done. Namely, all host names in URLs (like the listen
URL) should be resolved to IP addresses.

One possible downside to this change is that receptor processes might
bind to a port, but then reject messages for a period of time before
becoming fully functioning. In this case, merely checking for port
binding is not enough to ensure that the node is usable and that a test
can continue. If this does occur, I would recommend investigating
whether this bug is strictly necessary, and implementing an additional
network check while this investigation occurs.