### PR TITLE
Let scripts call correct executables

### DIFF
--- a/scripts/lint-flake8.sh
+++ b/scripts/lint-flake8.sh
@@ -2,4 +2,4 @@
 # coding=utf-8
 set -euo pipefail
 
-poetry run yamllint --strict .
+poetry run flake8

--- a/scripts/lint-yamllint.sh
+++ b/scripts/lint-yamllint.sh
@@ -2,4 +2,4 @@
 # coding=utf-8
 set -euo pipefail
 
-poetry run flake8
+poetry run yamllint --strict .


### PR DESCRIPTION
Let `lint-flake8.sh` call flake8, and let `lint-yamllint.sh` call
yamllint.