### PR TITLE
Drop Node.create_from_config

### DIFF
--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -58,18 +58,8 @@ class Node:
             self.data_path = f"/tmp/receptor/{str(self.uuid)}"
         if not self.listen:
             self.listen = f"receptor://0.0.0.0:{random_port()}"
-
-    @staticmethod
-    def create_from_config(config):
-        return Node(
-            name=config["name"],
-            listen=config.get("listen", f"receptor://0.0.0.0:{random_port()}"),
-            connections=config.get("connections", []) or [],
-            stats_enable=config.get("stats_enable", False),
-            stats_port=config.get("stats_port", None) or random_port(),
-            profile=config.get("profile", False),
-            data_path=config.get("data_path", None),
-        )
+        if self.stats_enable and not self.stats_port:
+            self.stats_port = random_port()
 
     def _construct_run_command(self):
         if self.profile:
@@ -311,9 +301,6 @@ class DiagNode(Node):
             f"http://{self.api_address}:{self.api_port}/add_peer?peer={coded_peer}"
         )
 
-    def create_from_config(config):
-        raise NotImplementedError
-
 
 @attr.s
 class Mesh:
@@ -470,7 +457,7 @@ class Mesh:
 
         mesh = Mesh(use_diag_node=use_diag_node)
         for node_name, definition in data["nodes"].items():
-            node = Node.create_from_config(definition)
+            node = Node(**definition)
             mesh.add_node(node)
 
         return mesh

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -20,10 +20,7 @@ def test_str_stopped_node_error():
 
 def test_str_route_mismatch_error():
     """Call ``str`` on a ``RouteMismatchError``."""
-    # Node.__init__ doesn't require all required attributes. It should be fixed, but in the
-    # meantime, using Node.create_from_config works around this issue, as it provides many default
-    # values.
-    node = Node.create_from_config({"name": str(uuid.uuid4())})
+    node = Node(str(uuid.uuid4()))
     node.start()
     mesh = Mesh()
     mesh.add_node(node)


### PR DESCRIPTION
This method is problematic for two reasons:

*   It duplicates initialization work already done by `Node.__init__`.
    Both methods both give default values to `controller`, `listen`, and
    so on.
*   It constrains the attributes which may be specified via yaml
    configuration files. As is, `Node.create_from_config` plucks a
    hard-coded set of attributes from the configuration file and passes
    them through to `Node.__init__`. Simply calling `Node(**definition)`
    is infinitely more flexible.