### PR TITLE
Return listen_port of 8888 by default

### DIFF
--- a/receptor_affinity/mesh.py
+++ b/receptor_affinity/mesh.py
@@ -183,7 +183,10 @@ class Node:
 
     @property
     def listen_port(self) -> int:
-        return urlparse(self.listen).port
+        port = urlparse(self.listen).port
+        if port:
+            return port
+        return 8888
 
     def get_metrics(self):
         stats = requests.get(f"http://{self.hostname}:{self.stats_port}/metrics")

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -101,3 +101,15 @@ def test_node_pgid_v3():
     node.stop()
     with pytest.raises(NodeUnavailableError):
         node.pgid
+
+
+def test_node_listen_port_v1():
+    """Call ``Node.listen_port`` on a node for which a port is specified."""
+    node = Node(str(uuid.uuid4()), listen="receptor://127.0.0.1:8825")
+    assert node.listen_port == 8825
+
+
+def test_node_listen_port_v2():
+    """Call ``Node.listen_port`` on a node for which no port is specified."""
+    node = Node(str(uuid.uuid4()), listen="receptor://127.0.0.1")
+    assert node.listen_port == 8888


### PR DESCRIPTION
This is useful in cases where the listen string lacks a port, like:

    receptor://127.0.0.1

This change will ensure that the `listen_port` method better adheres to
its signature (by more consistently returning an int) and simplify
certain tests, e.g. by dropping the `_wait_for_conns` method added in
https://github.com/project-receptor/receptor/pull/139