### PR TITLE
Remove dependency on typing because it is now in the stdlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ setuptools = "*"  # For pkg_resources
 wait-for = "^1.1.1"
 python-dateutil = "^2.8.1"
 prometheus-client = "^0.7.1"
-typing = "^3.7.4"
 psutil = "^5.6.7"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
See https://github.com/python/typing/issues/573